### PR TITLE
Spanish translation

### DIFF
--- a/Languages/Spanish/Keyed/Keys.xml
+++ b/Languages/Spanish/Keyed/Keys.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+  <Fluffy_Relations>Relations Tab</Fluffy_Relations>
+  <Fluffy_Relations.Possesive>{0} </Fluffy_Relations.Possesive>
+  <Fluffy_Relations.Colonists>Colonos</Fluffy_Relations.Colonists>
+  <Fluffy_Relations.Factions>Facciones</Fluffy_Relations.Factions>
+  <Fluffy.Relations.Colony>Colonia</Fluffy.Relations.Colony>
+  <Fluffy_Relations.SourceButtonTip>Cambiar entre colonos y facciones</Fluffy_Relations.SourceButtonTip>
+  <Fluffy_Relations.Relations>Relaciones</Fluffy_Relations.Relations>
+  <Fluffy_Relations.Interactions>Interacciones</Fluffy_Relations.Interactions>
+  <Fluffy_Relations.KidnappedColonists>Colonos secuestrados</Fluffy_Relations.KidnappedColonists>
+  <Fluffy_Relations.OpinionOf> opinión de {0}: {1}</Fluffy_Relations.OpinionOf>
+  <Fluffy_Relations.NothingSelected></Fluffy_Relations.NothingSelected>
+  <Fluffy_Relations.ModeCircleTip>Cambiar al diseño circular</Fluffy_Relations.ModeCircleTip>
+  <Fluffy_Relations.GraphResetTip>Reiniciar el diseño dinámico</Fluffy_Relations.GraphResetTip>
+  <Fluffy_Relations.NodeInteractionTip>Clic izquierdo para seleccionar.\nClic derecho para desbloquear.\nClic y arrastre para mover.\n</Fluffy_Relations.NodeInteractionTip>
+  <Fluffy_Relations.ModeGraphTip>Cambiar al diseño dinámico</Fluffy_Relations.ModeGraphTip>
+  <Fluffy_Relations.RelationOptions>Parámetros en relaciones</Fluffy_Relations.RelationOptions>
+  <Fluffy_Relations.GraphOptions>Parámetros del diseño dinámico</Fluffy_Relations.GraphOptions>
+  <Fluffy_Relations.Graph.MaxIterations>Iteraciones máximas</Fluffy_Relations.Graph.MaxIterations>
+  <Fluffy_Relations.Graph.MaxIterationsTip>Las iteraciones máximas (frames) que se ejecutarán en el gráfico dinámico.</Fluffy_Relations.Graph.MaxIterationsTip>
+  <Fluffy_Relations.Graph.Threshold>Umbral de movimiento</Fluffy_Relations.Graph.Threshold>
+  <Fluffy_Relations.Graph.ThresholdTip>Cuando todos los nodos se mueven por debajo del umbral, el gráfico alcanza un estado estable, por lo que no es necesario realizar más iteraciones.</Fluffy_Relations.Graph.ThresholdTip>
+  <Fluffy_Relations.Graph.MaxTemperature>Temperatura inicial</Fluffy_Relations.Graph.MaxTemperature>
+  <Fluffy_Relations.Graph.MaxTemperatureTip>La temperatura controla los niveles de energía en el sistema, los valores más altos presentan un movimiento más brusco y rápido, pero también es más probable que "exploten". La temperatura se reduce a medida que se producen las iteraciones, provocando una desaceleración gradual del movimiento.</Fluffy_Relations.Graph.MaxTemperatureTip>
+  <Fluffy_Relations.Graph.CentralConstant>Fuerza central</Fluffy_Relations.Graph.CentralConstant>
+  <Fluffy_Relations.Graph.CentralConstantTip>La fuerza central es la presión hacia el centro del gráfico aplicada a todos los nodos, para evitar que los nodos no conectados se alejen.</Fluffy_Relations.Graph.CentralConstantTip>
+  <Fluffy_Relations.Graph.AttractiveConstant>Fuerza de atracción</Fluffy_Relations.Graph.AttractiveConstant>
+  <Fluffy_Relations.Graph.AttractiveConstantTip>Una fuerza de atracción se aplica entre los peones relacionados, y se incrementa aún más en función de la opinión entre los peones.</Fluffy_Relations.Graph.AttractiveConstantTip>
+  <Fluffy_Relations.Graph.RepulsiveConstant>Fuerza repulsiva</Fluffy_Relations.Graph.RepulsiveConstant>
+  <Fluffy_Relations.Graph.RepulsiveConstantTip>Una fuerza repulsiva se aplica a todos los nodos y los empuja lejos entre si. Esto evita que los nodos se superpongan y los distribuye uniformemente.</Fluffy_Relations.Graph.RepulsiveConstantTip>
+  <Fluffy_Relations.InvalidFloat>Número inválido. Por favor, usar '{0}' como separador decimal.</Fluffy_Relations.InvalidFloat>
+  <Fluffy_Relations.InvalidInteger>Número inválido. Sólo se permiten números enteros.</Fluffy_Relations.InvalidInteger>
+  <Fluffy_Relations.GraphOptionsInformation>Las siguientes opciones permiten ajustar con precisión el algoritmo que controla el gráfico de fuerza dirigida - la vista dinámica de los colonos y sus relaciones. Cuidado, cambiar de estos valores <b>puede provocar un comportamiento erratico</b>. Especial cuidado con la temperatura inicial, incluso valores ligeramente más altos conducirán rápidamente a gráficos que "explotan". El espacio entre los colonos se puede controlar con eficacia disminuyendo/incrementando la fuerza de repulsión - Ajustar valores entre 500 y 5000 para ver el efecto.</Fluffy_Relations.GraphOptionsInformation>
+  <Fluffy_Relations.SocialThoughsOfOthers>Efectos sociales actuales</Fluffy_Relations.SocialThoughsOfOthers>
+  !<Fluffy_Relations.ThoughtOptions>Desventajas sociales registradas</Fluffy_Relations.ThoughtOptions>
+
+  <Fluffy_Relations.SelectLeaderTip>Cambiar el líder</Fluffy_Relations.SelectLeaderTip>
+  <Fluffy_Relations.FirstDegreeTip_On>Incluir parientes</Fluffy_Relations.FirstDegreeTip_On>
+  <Fluffy_Relations.FirstDegreeTip_Off>Excluir parientes</Fluffy_Relations.FirstDegreeTip_Off>
+</LanguageData>

--- a/Languages/Spanish/Keyed/Keys.xml
+++ b/Languages/Spanish/Keyed/Keys.xml
@@ -33,7 +33,7 @@
   <Fluffy_Relations.InvalidInteger>Número inválido. Sólo se permiten números enteros.</Fluffy_Relations.InvalidInteger>
   <Fluffy_Relations.GraphOptionsInformation>Las siguientes opciones permiten ajustar con precisión el algoritmo que controla el gráfico de fuerza dirigida - la vista dinámica de los colonos y sus relaciones. Cuidado, cambiar de estos valores <b>puede provocar un comportamiento erratico</b>. Especial cuidado con la temperatura inicial, incluso valores ligeramente más altos conducirán rápidamente a gráficos que "explotan". El espacio entre los colonos se puede controlar con eficacia disminuyendo/incrementando la fuerza de repulsión - Ajustar valores entre 500 y 5000 para ver el efecto.</Fluffy_Relations.GraphOptionsInformation>
   <Fluffy_Relations.SocialThoughsOfOthers>Efectos sociales actuales</Fluffy_Relations.SocialThoughsOfOthers>
-  !<Fluffy_Relations.ThoughtOptions>Desventajas sociales registradas</Fluffy_Relations.ThoughtOptions>
+  <Fluffy_Relations.ThoughtOptions>Desventajas sociales registradas</Fluffy_Relations.ThoughtOptions>
 
   <Fluffy_Relations.SelectLeaderTip>Cambiar el líder</Fluffy_Relations.SelectLeaderTip>
   <Fluffy_Relations.FirstDegreeTip_On>Incluir parientes</Fluffy_Relations.FirstDegreeTip_On>

--- a/Languages/SpanishLatin/Keyed/Keys.xml
+++ b/Languages/SpanishLatin/Keyed/Keys.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+  <Fluffy_Relations>Relations Tab</Fluffy_Relations>
+  <Fluffy_Relations.Possesive>{0} </Fluffy_Relations.Possesive>
+  <Fluffy_Relations.Colonists>Colonos</Fluffy_Relations.Colonists>
+  <Fluffy_Relations.Factions>Facciones</Fluffy_Relations.Factions>
+  <Fluffy.Relations.Colony>Colonia</Fluffy.Relations.Colony>
+  <Fluffy_Relations.SourceButtonTip>Cambiar entre colonos y facciones</Fluffy_Relations.SourceButtonTip>
+  <Fluffy_Relations.Relations>Relaciones</Fluffy_Relations.Relations>
+  <Fluffy_Relations.Interactions>Interacciones</Fluffy_Relations.Interactions>
+  <Fluffy_Relations.KidnappedColonists>Colonos secuestrados</Fluffy_Relations.KidnappedColonists>
+  <Fluffy_Relations.OpinionOf> opinión de {0}: {1}</Fluffy_Relations.OpinionOf>
+  <Fluffy_Relations.NothingSelected></Fluffy_Relations.NothingSelected>
+  <Fluffy_Relations.ModeCircleTip>Cambiar al diseño circular</Fluffy_Relations.ModeCircleTip>
+  <Fluffy_Relations.GraphResetTip>Reiniciar el diseño dinámico</Fluffy_Relations.GraphResetTip>
+  <Fluffy_Relations.NodeInteractionTip>Clic izquierdo para seleccionar.\nClic derecho para desbloquear.\nClic y arrastre para mover.\n</Fluffy_Relations.NodeInteractionTip>
+  <Fluffy_Relations.ModeGraphTip>Cambiar al diseño dinámico</Fluffy_Relations.ModeGraphTip>
+  <Fluffy_Relations.RelationOptions>Parámetros en relaciones</Fluffy_Relations.RelationOptions>
+  <Fluffy_Relations.GraphOptions>Parámetros del diseño dinámico</Fluffy_Relations.GraphOptions>
+  <Fluffy_Relations.Graph.MaxIterations>Iteraciones máximas</Fluffy_Relations.Graph.MaxIterations>
+  <Fluffy_Relations.Graph.MaxIterationsTip>Las iteraciones máximas (frames) que se ejecutarán en el gráfico dinámico.</Fluffy_Relations.Graph.MaxIterationsTip>
+  <Fluffy_Relations.Graph.Threshold>Umbral de movimiento</Fluffy_Relations.Graph.Threshold>
+  <Fluffy_Relations.Graph.ThresholdTip>Cuando todos los nodos se mueven por debajo del umbral, el gráfico alcanza un estado estable, por lo que no es necesario realizar más iteraciones.</Fluffy_Relations.Graph.ThresholdTip>
+  <Fluffy_Relations.Graph.MaxTemperature>Temperatura inicial</Fluffy_Relations.Graph.MaxTemperature>
+  <Fluffy_Relations.Graph.MaxTemperatureTip>La temperatura controla los niveles de energía en el sistema, los valores más altos presentan un movimiento más brusco y rápido, pero también es más probable que "exploten". La temperatura se reduce a medida que se producen las iteraciones, provocando una desaceleración gradual del movimiento.</Fluffy_Relations.Graph.MaxTemperatureTip>
+  <Fluffy_Relations.Graph.CentralConstant>Fuerza central</Fluffy_Relations.Graph.CentralConstant>
+  <Fluffy_Relations.Graph.CentralConstantTip>La fuerza central es la presión hacia el centro del gráfico aplicada a todos los nodos, para evitar que los nodos no conectados se alejen.</Fluffy_Relations.Graph.CentralConstantTip>
+  <Fluffy_Relations.Graph.AttractiveConstant>Fuerza de atracción</Fluffy_Relations.Graph.AttractiveConstant>
+  <Fluffy_Relations.Graph.AttractiveConstantTip>Una fuerza de atracción se aplica entre los peones relacionados, y se incrementa aún más en función de la opinión entre los peones.</Fluffy_Relations.Graph.AttractiveConstantTip>
+  <Fluffy_Relations.Graph.RepulsiveConstant>Fuerza repulsiva</Fluffy_Relations.Graph.RepulsiveConstant>
+  <Fluffy_Relations.Graph.RepulsiveConstantTip>Una fuerza repulsiva se aplica a todos los nodos y los empuja lejos entre si. Esto evita que los nodos se superpongan y los distribuye uniformemente.</Fluffy_Relations.Graph.RepulsiveConstantTip>
+  <Fluffy_Relations.InvalidFloat>Número inválido. Por favor, usar '{0}' como separador decimal.</Fluffy_Relations.InvalidFloat>
+  <Fluffy_Relations.InvalidInteger>Número inválido. Sólo se permiten números enteros.</Fluffy_Relations.InvalidInteger>
+  <Fluffy_Relations.GraphOptionsInformation>Las siguientes opciones permiten ajustar con precisión el algoritmo que controla el gráfico de fuerza dirigida - la vista dinámica de los colonos y sus relaciones. Cuidado, cambiar de estos valores <b>puede provocar un comportamiento erratico</b>. Especial cuidado con la temperatura inicial, incluso valores ligeramente más altos conducirán rápidamente a gráficos que "explotan". El espacio entre los colonos se puede controlar con eficacia disminuyendo/incrementando la fuerza de repulsión - Ajustar valores entre 500 y 5000 para ver el efecto.</Fluffy_Relations.GraphOptionsInformation>
+  <Fluffy_Relations.SocialThoughsOfOthers>Efectos sociales actuales</Fluffy_Relations.SocialThoughsOfOthers>
+  !<Fluffy_Relations.ThoughtOptions>Desventajas sociales registradas</Fluffy_Relations.ThoughtOptions>
+
+  <Fluffy_Relations.SelectLeaderTip>Cambiar el líder</Fluffy_Relations.SelectLeaderTip>
+  <Fluffy_Relations.FirstDegreeTip_On>Incluir parientes</Fluffy_Relations.FirstDegreeTip_On>
+  <Fluffy_Relations.FirstDegreeTip_Off>Excluir parientes</Fluffy_Relations.FirstDegreeTip_Off>
+</LanguageData>

--- a/Languages/SpanishLatin/Keyed/Keys.xml
+++ b/Languages/SpanishLatin/Keyed/Keys.xml
@@ -33,7 +33,7 @@
   <Fluffy_Relations.InvalidInteger>Número inválido. Sólo se permiten números enteros.</Fluffy_Relations.InvalidInteger>
   <Fluffy_Relations.GraphOptionsInformation>Las siguientes opciones permiten ajustar con precisión el algoritmo que controla el gráfico de fuerza dirigida - la vista dinámica de los colonos y sus relaciones. Cuidado, cambiar de estos valores <b>puede provocar un comportamiento erratico</b>. Especial cuidado con la temperatura inicial, incluso valores ligeramente más altos conducirán rápidamente a gráficos que "explotan". El espacio entre los colonos se puede controlar con eficacia disminuyendo/incrementando la fuerza de repulsión - Ajustar valores entre 500 y 5000 para ver el efecto.</Fluffy_Relations.GraphOptionsInformation>
   <Fluffy_Relations.SocialThoughsOfOthers>Efectos sociales actuales</Fluffy_Relations.SocialThoughsOfOthers>
-  !<Fluffy_Relations.ThoughtOptions>Desventajas sociales registradas</Fluffy_Relations.ThoughtOptions>
+  <Fluffy_Relations.ThoughtOptions>Desventajas sociales registradas</Fluffy_Relations.ThoughtOptions>
 
   <Fluffy_Relations.SelectLeaderTip>Cambiar el líder</Fluffy_Relations.SelectLeaderTip>
   <Fluffy_Relations.FirstDegreeTip_On>Incluir parientes</Fluffy_Relations.FirstDegreeTip_On>


### PR DESCRIPTION
There are still 3 lines to translate that are not available in "Keyed":
"Lower opinion threshold", "Upper opinion threshold" and "Pawns with an opinion of eachother above this threshold will always be visually linked.". They belong to "Settings.cs", but I don't dare touch anything.